### PR TITLE
explicitly set status bar color

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,12 +14,12 @@
 
     <application
         android:label="@string/app_label"
+        android:theme="@style/Theme"
         android:largeHeap="true"
     >
         <activity
             android:name=".LogcatActivity"
             android:permission="app.grapheneos.logviewer.SHOW_LOGCAT"
-            android:theme="@android:style/Theme.DeviceDefault.DayNight"
             android:documentLaunchMode="always"
             android:exported="true" >
 
@@ -34,7 +34,6 @@
         <activity
             android:name=".ErrorReportActivity"
             android:permission="app.grapheneos.logviewer.SHOW_ERROR_REPORT"
-            android:theme="@android:style/Theme.DeviceDefault.DayNight"
             android:documentLaunchMode="always"
             android:exported="true" >
 

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme" parent="@android:style/Theme.DeviceDefault.DayNight">
+        <item name="android:statusBarColor">#555</item>
+    </style>
+</resources>


### PR DESCRIPTION
Default color produces low contrast for status bar icons when a light theme is used.